### PR TITLE
This makes it easier for people to install with the PHP package manager, composer

### DIFF
--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -14,7 +14,7 @@ if (function_exists('getenv')) {
 	if (getenv('AGILECRM_DEV')) {
 		define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
 		define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL'));
-		define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY');
+		define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY'));
 	}
 	else {
         define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -10,16 +10,16 @@
 
 // use a dotenv file if exists to set credentials
 
-if (function_exists('getenv')) {
+if (class_exists('Dotenv')) {
 	if (getenv('AGILECRM_DEV')) {
-		define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
-		define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL'));
-		define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY'));
+		$AGILE_DOMAIN = getenv('AGILECRM_DEV_DOMAIN'));
+		$AGILE_USER_EMAIL = getenv('AGILECRM_DEV_USER_EMAIL'));
+		$AGILE_REST_API_KEY = getenv('AGILECRM_DEV_REST_API_KEY'));
 	}
 	else {
-        define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
-        define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL'));
-        define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY'));
+        $AGILE_DOMAIN = getenv('AGILECRM_DEV_DOMAIN'));
+        $AGILE_USER_EMAIL = getenv('AGILECRM_DEV_USER_EMAIL'));
+        $AGILE_REST_API_KEY = getenv('AGILECRM_DEV_REST_API_KEY'));
 	}
 }
 
@@ -27,19 +27,21 @@ if (function_exists('getenv')) {
 // attempt to use hardcoded credentials here
 // HARDCODED DOMAIN, EMAIL, AND API KEY GO HERE
 
-if (!defined('AGILE_DOMAIN') || strlen(trim(AGILE_DOMAIN)) < 1) {
+if (!isset($AGILE_DOMAIN) || strlen(trim($AGILE_DOMAIN)) < 1) {
     # Enter your domain name , agile email and agile api key
-    define('AGILE_DOMAIN', 'YOUR_AGILE_DOMAIN');  # Example : define('domain','jim');
-    define('AGILE_USER_EMAIL', 'YOUR_AGILE_USER_EMAIL');
-    define('AGILE_REST_API_KEY', 'YOUR_AGILE_REST_API_KEY');
+    $AGILE_DOMAIN = 'YOUR_AGILE_DOMAIN');  # Example : define('domain','jim');
+    $AGILE_USER_EMAIL = 'YOUR_AGILE_USER_EMAIL');
+    $AGILE_REST_API_KEY ='YOUR_AGILE_REST_API_KEY');
 }
+
+
 
 function curl_wrap($entity, $data, $method, $content_type) {
     if ($content_type == NULL) {
         $content_type = 'application/json';
     }
     
-    $agile_url = 'https://' . AGILE_DOMAIN . '.agilecrm.com/dev/api/' . $entity;
+    $agile_url = 'https://' . $AGILE_DOMAIN . '.agilecrm.com/dev/api/' . $entity;
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -75,7 +77,7 @@ function curl_wrap($entity, $data, $method, $content_type) {
         'Content-type : $content_type;', 'Accept : application/json'
     ));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_USERPWD, AGILE_USER_EMAIL . ':' . AGILE_REST_API_KEY);
+    curl_setopt($ch, CURLOPT_USERPWD, $AGILE_USER_EMAIL . ':' . $AGILE_REST_API_KEY);
     curl_setopt($ch, CURLOPT_TIMEOUT, 120);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
     $output = curl_exec($ch);

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -27,7 +27,7 @@ if (function_exists('getenv')) {
 // attempt to use hardcoded credentials here
 // HARDCODED DOMAIN, EMAIL, AND API KEY GO HERE
 
-if (!isset(AGILE_DOMAIN) || len(AGILE_DOMAIN < 1)) {
+if (!defined(AGILE_DOMAIN) || strlen(trim(AGILE_DOMAIN)) < 1) {
     # Enter your domain name , agile email and agile api key
     define('AGILE_DOMAIN', 'YOUR_AGILE_DOMAIN');  # Example : define('domain','jim');
     define('AGILE_USER_EMAIL', 'YOUR_AGILE_USER_EMAIL');

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -8,51 +8,71 @@
  * @author    Agile CRM developers <Ghanshyam>
  */
 
+// use a dotenv file if exists to set credentials
 
-# Enter your domain name , agile email and agile api key
-define("AGILE_DOMAIN", "YOUR_AGILE_DOMAIN");  # Example : define("domain","jim");
-define("AGILE_USER_EMAIL", "YOUR_AGILE_USER_EMAIL");
-define("AGILE_REST_API_KEY", "YOUR_AGILE_REST_API_KEY");
+if (function_exists('getenv')) {
+	if (getenv('AGILECRM_DEV')) {
+		define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
+		define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL'));
+		define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY');
+	}
+	else {
+        define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
+        define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL');
+        define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY');
+	}
+}
+
+// if the domain is not set, it is likely the others are unset as well
+// attempt to use hardcoded credentials here
+// HARDCODED DOMAIN, EMAIL, AND API KEY GO HERE
+
+if (!isset(AGILE_DOMAIN) || len(AGILE_DOMAIN < 1)) {
+    # Enter your domain name , agile email and agile api key
+    define('AGILE_DOMAIN', 'YOUR_AGILE_DOMAIN');  # Example : define('domain','jim');
+    define('AGILE_USER_EMAIL', 'YOUR_AGILE_USER_EMAIL');
+    define('AGILE_REST_API_KEY', 'YOUR_AGILE_REST_API_KEY');
+}
 
 function curl_wrap($entity, $data, $method, $content_type) {
     if ($content_type == NULL) {
-        $content_type = "application/json";
+        $content_type = 'application/json';
     }
     
-    $agile_url = "https://" . AGILE_DOMAIN . ".agilecrm.com/dev/api/" . $entity;
+    $agile_url = 'https://' . AGILE_DOMAIN . '.agilecrm.com/dev/api/' . $entity;
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
     curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
     curl_setopt($ch, CURLOPT_UNRESTRICTED_AUTH, true);
     switch ($method) {
-        case "POST":
+        case 'POST':
             $url = $agile_url;
             curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
             curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
             break;
-        case "GET":
+        case 'GET':
             $url = $agile_url;
             curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
             break;
-        case "PUT":
+        case 'PUT':
             $url = $agile_url;
             curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
             curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
             break;
-        case "DELETE":
+        case 'DELETE':
             $url = $agile_url;
             curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
             break;
         default:
             break;
     }
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-        "Content-type : $content_type;", 'Accept : application/json'
+        'Content-type : $content_type;', 'Accept : application/json'
     ));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_USERPWD, AGILE_USER_EMAIL . ':' . AGILE_REST_API_KEY);

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -11,9 +11,9 @@
 // use a dotenv file if exists to set credentials
 
 if (class_exists('Dotenv')) {
-    $AGILE_DOMAIN = getenv('AGILECRM_DOMAIN'));
-    $AGILE_USER_EMAIL = getenv('AGILECRM_USER_EMAIL'));
-    $AGILE_REST_API_KEY = getenv('AGILECRM_REST_API_KEY'));
+    $AGILE_DOMAIN = getenv('AGILECRM_DOMAIN');
+    $AGILE_USER_EMAIL = getenv('AGILECRM_USER_EMAIL');
+    $AGILE_REST_API_KEY = getenv('AGILECRM_REST_API_KEY');
 }
 
 // if the domain is not set, it is likely the others are unset as well

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -27,8 +27,6 @@ if (!isset($AGILE_DOMAIN) || strlen(trim($AGILE_DOMAIN)) < 1) {
     $AGILE_REST_API_KEY ='YOUR_AGILE_REST_API_KEY');
 }
 
-
-
 function curl_wrap($entity, $data, $method, $content_type) {
     if ($content_type == NULL) {
         $content_type = 'application/json';
@@ -67,7 +65,7 @@ function curl_wrap($entity, $data, $method, $content_type) {
             break;
     }
     curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-        'Content-type : $content_type;', 'Accept : application/json'
+        "Content-type : $content_type;", 'Accept : application/json'
     ));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_USERPWD, $AGILE_USER_EMAIL . ':' . $AGILE_REST_API_KEY);

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -11,16 +11,9 @@
 // use a dotenv file if exists to set credentials
 
 if (class_exists('Dotenv')) {
-	if (getenv('AGILECRM_DEV')) {
-		$AGILE_DOMAIN = getenv('AGILECRM_DEV_DOMAIN'));
-		$AGILE_USER_EMAIL = getenv('AGILECRM_DEV_USER_EMAIL'));
-		$AGILE_REST_API_KEY = getenv('AGILECRM_DEV_REST_API_KEY'));
-	}
-	else {
-        $AGILE_DOMAIN = getenv('AGILECRM_DEV_DOMAIN'));
-        $AGILE_USER_EMAIL = getenv('AGILECRM_DEV_USER_EMAIL'));
-        $AGILE_REST_API_KEY = getenv('AGILECRM_DEV_REST_API_KEY'));
-	}
+    $AGILE_DOMAIN = getenv('AGILECRM_DOMAIN'));
+    $AGILE_USER_EMAIL = getenv('AGILECRM_USER_EMAIL'));
+    $AGILE_REST_API_KEY = getenv('AGILECRM_REST_API_KEY'));
 }
 
 // if the domain is not set, it is likely the others are unset as well

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -18,8 +18,8 @@ if (function_exists('getenv')) {
 	}
 	else {
         define('AGILE_DOMAIN', getenv('AGILECRM_DEV_DOMAIN'));
-        define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL');
-        define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY');
+        define('AGILE_USER_EMAIL', getenv('AGILECRM_DEV_USER_EMAIL'));
+        define('AGILE_REST_API_KEY', getenv('AGILECRM_DEV_REST_API_KEY'));
 	}
 }
 

--- a/CurlLib/curlwrap_v2.php
+++ b/CurlLib/curlwrap_v2.php
@@ -27,7 +27,7 @@ if (function_exists('getenv')) {
 // attempt to use hardcoded credentials here
 // HARDCODED DOMAIN, EMAIL, AND API KEY GO HERE
 
-if (!defined(AGILE_DOMAIN) || strlen(trim(AGILE_DOMAIN)) < 1) {
+if (!defined('AGILE_DOMAIN') || strlen(trim(AGILE_DOMAIN)) < 1) {
     # Enter your domain name , agile email and agile api key
     define('AGILE_DOMAIN', 'YOUR_AGILE_DOMAIN');  # Example : define('domain','jim');
     define('AGILE_USER_EMAIL', 'YOUR_AGILE_USER_EMAIL');

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Table of contents
 
 **[Requirements](#requirements)**
 
+**[Install](#install)**
+
 **[Usage](#usage)**
 
 **[1 Contact](#1-contact)**
@@ -130,6 +132,28 @@ $data = json_encode($data);
 
 - Two folder CurlLib and Tester
 - Can directly test Tester's any file after setting domain,email and api key of curlwrap_v2.php (CurlLib folder)
+
+## Install
+
+### Simple
+
+Merely include, require, include_once, or require once the CurlLib/curlwrap_v2.php file as the index.php file shows.
+
+### Composer
+
+Modify your project composer.json to include these properties.
+
+```javascript
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/agilecrm/php-api.git"
+        }
+    ],
+    "require": {
+        "agilecrm/php-api":"^3.1.0"
+    },
+```
 
 ## Usage
 
@@ -719,6 +743,5 @@ $currentUser = curl_wrap("users/current-user", null, "GET", NULL);
 echo $currentUser;
 ```
 ----
-
 
 - The curlwrap_v*.php is based on https://gist.github.com/apanzerj/2920899 authored by [Adam Panzer](https://github.com/apanzerj).

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $data = json_encode($data);
 
 ### Simple
 
-Merely include, require, include_once, or require once the CurlLib/curlwrap_v2.php file as the index.php file shows.
+Merely include, require, include_once, or require_once the CurlLib/curlwrap_v2.php file as the index.php file shows.
 
 ### Composer
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,59 @@
+{
+    "name": "agilecrm/php-api",
+    "description": "This is the AgileCRM API PHP interface helper library",
+    "version": "3.0.0",
+    "type": "library",
+    "keywords": ["agilecrm", "api", "http"],
+    "homepage": "https://www.agilecrm.com",
+    "time": "2018-08-20",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Adam Panzer",
+            "email": "apanzerj@gmail.com",
+            "homepage": "http://cra.ptaculo.us",
+            "role": "Developer"
+        },
+        {
+            "name": "Ghanshyam Raut",
+            "email": "ghanshyam.raut@agilecrm.com",
+            "homepage": "https://www.agilecrm.com",
+            "role": "Developer"
+        },
+        {
+            "name": "Brad Chesney",
+            "email": "bradchesney79@gmail.com",
+            "homepage": "https://splashfinancial.com",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "email": "care@agilecrm.com",
+        "issues": "https://github.com/agilecrm/php-api/issues",
+        "source": "https://github.com/agilecrm/php-api",
+        "docs": "https://www.agilecrm.com/api"
+    },
+    "require": {
+    },
+    "require-dev": {
+    },
+    "autoload": {
+        "files": ["autoload.php"]
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "AgileCRM\\Tests": "Tester/"
+        }
+    },
+    "target-dir": "",
+    "minimum-stability": "stable",
+    "repositories": "",
+    "config": {
+        "use-include-path": true
+    },
+    "archive": {},
+    "prefer-stable": true,
+    "scripts": {},
+    "extra": "",
+    "bin": ""
+}

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "AgileCRM\\Tests": "Tester/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "config": {
         "use-include-path": true
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "agilecrm/php-api",
     "description": "This is the AgileCRM API PHP interface helper library",
-    "version": "3.0.0",
     "type": "library",
     "keywords": ["agilecrm", "api", "http"],
     "homepage": "https://www.agilecrm.com",
@@ -45,15 +44,9 @@
             "AgileCRM\\Tests": "Tester/"
         }
     },
-    "target-dir": "",
     "minimum-stability": "stable",
-    "repositories": "",
     "config": {
         "use-include-path": true
     },
-    "archive": {},
-    "prefer-stable": true,
-    "scripts": {},
-    "extra": "",
-    "bin": ""
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
     },
     "autoload": {
-        "files": ["autoload.php"]
+        "files": ["index.php"]
     },
     "autoload-dev": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
     },
     "autoload": {
-        "files": ["index.php"]
+        "files": ["CurlLib/curlwrap_v2.php"]
     },
     "autoload-dev": {
         "psr-0": {


### PR DESCRIPTION
Three things:

Changed from the marginally more resource consuming doublequoted strings to singlequoted strings
Added looking for settings from a dotenv .env file
Added a composer.json file

I've tagged this commit as v3.1.0 in my fork...

Look over the composer.json carefully -- your use case probably is fit best by the MIT license, maybe not. Your call.

But, it is a good solid start on helping out people using the wildly popular composer PHP package manager. Also, if you ever wanted to publish the repo to the packagist-- which is the PHP paralell of the nodejs npmjs or the python cheesefactory/warehouse.